### PR TITLE
Document problematic nature of rand()

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for Crypt-Random-Source
 
 {{$NEXT}}
+          - Document issues with rand() in previous release
 
 0.13      2018-04-08 01:07:39Z
           - remove rand() fallback, which could be used by get_weak and is not safe

--- a/lib/Crypt/Random/Source.pm
+++ b/lib/Crypt/Random/Source.pm
@@ -69,6 +69,18 @@ L<Crypt::Random::Source::Factory>, calling get
 
 =back
 
+=head1 CAVEATS
+
+In versions prior to 0.13, C<rand> could be used as a result of calling
+C<get_weak>, or C<get>, if no random device was available. This implies that
+not explicitly asking for C<get_strong> on a non POSIX operating system (e.g.
+Win32 without the Win32 backend) could have resulted in non cryptographically
+random data.
+
+Relatedly, the characterization of C<urandom> as a weak source of randomness is
+also largely a misconception, see L<https://www.2uo.de/myths-about-urandom/>
+for example.
+
 =head1 SEE ALSO
 
 L<Crypt::Random>, L<Crypt::Util>


### PR DESCRIPTION
Also discusses misconceptions about urandom. After 0.13, all usage
of this module should provide cryptographically secure data in
reasonable circumstances, with the very slight caveats of urandom being
used under misconfigured linux machines shortly after boot without
unique saved entropy.

Usage of get_strong is unaffected and was safe previously as well.